### PR TITLE
Preserve original request timestamp across retries to prevent refresh loops

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idea-fragments/request-helper",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "author": "IdeaFragments LLC",
   "browserslist": {
     "production": [

--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -15,7 +15,7 @@ import { isString }      from "utils/typeCheckers"
 
 const logger = new Logger("request")
 
-export const request = async <T>(rp: RequestParams & Configuration): Promise<T> => {
+export const request = async <T>(rp: RequestParams & Configuration, originalRequestInitiatedAt?: number): Promise<T> => {
   const {
           afterRequestInterceptor,
           beforeRequest,
@@ -32,7 +32,7 @@ export const request = async <T>(rp: RequestParams & Configuration): Promise<T> 
         } = rp
   const extra = extraLogFields?.() ?? {}
   return await watchForErrors(errorInterceptor, async () => {
-    const requestInitiatedAt = Date.now()
+    const requestInitiatedAt = originalRequestInitiatedAt ?? Date.now()
     logger.writeInfo("[request:start]", { method, uri, query, ...extra })
     logger.writeInfo("[request:beforeHook:start]", { method, uri, ...extra })
     await beforeRequest(uri)
@@ -50,7 +50,7 @@ export const request = async <T>(rp: RequestParams & Configuration): Promise<T> 
 
     if (isUnauthorized(status)) {
       await unauthInterceptor(uri, requestInitiatedAt)
-      return await retry(rp)
+      return await retry(rp, requestInitiatedAt)
     }
 
     const respBody = await parseResponse(resp)
@@ -108,8 +108,8 @@ const finalizeBody = ({ headers = {}, body }: RequestInit) => {
 
 const isSuccessResponse = (status: number): boolean => status < 400
 const isUnauthorized    = (status: number): boolean => status === 401
-const retry             = <T>(rp: RequestParams & Configuration) =>
-  request<T>(rp)
+const retry             = <T>(rp: RequestParams & Configuration, originalRequestInitiatedAt: number) =>
+  request<T>(rp, originalRequestInitiatedAt)
 const watchForErrors    = async (
   errorInterceptor: ErrorInterceptor,
   f: Function,

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import {
   TokenSetter
 }                                     from "http/types"
 import { flow }                       from "lodash"
-import { Logger }      from "utils/Logger"
+import { Logger }                     from "utils/Logger"
 
 export type NewClientParams = {
   afterRequestInterceptor: AfterRequestInterceptor,
@@ -32,7 +32,7 @@ export type NewClientParams = {
 }
 
 const queueRequests = newRequestQueue({ waitUntilComplete: refreshAuthTokens })
-const logger        = new Logger("newHttp")
+const logger = new Logger("newHttp")
 
 export const newHttp = ({
                           afterRequestInterceptor,
@@ -76,8 +76,11 @@ export const newHttp = ({
   return http
 }
 
-export *                 from "http/types"
-export *                 from "http/ServerError"
-export *                 from "http/transformBodyToCamelCase"
-export *                 from "http/transformParamsToSnakeCase"
-export { enableLogging } from "utils/Logger"
+export * from "http/types"
+export * from "http/ServerError"
+export * from "http/transformBodyToCamelCase"
+export * from "http/transformParamsToSnakeCase"
+export {
+  disableLogging,
+  enableLogging
+}        from "utils/Logger"

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -2,13 +2,15 @@ import { Logger } from "@idea-fragments/logger-js"
 // @ts-ignore
 import { name }   from "../../package.json"
 
-export const enableLogging = () => Logger.addModules([
-  "configureUnauthInterceptor",
-  "ensureAuthTokensRefreshed",
-  "newHttp",
-  "newRequestQueue",
-  "request"
-])
+const MODULES = [
+          "configureUnauthInterceptor",
+          "ensureAuthTokensRefreshed",
+          "newHttp",
+          "newRequestQueue",
+          "request"
+        ]
+export const disableLogging = () => Logger.removeModules(MODULES)
+export const enableLogging = () => Logger.addModules(MODULES)
 
 Logger.packageName = name
 


### PR DESCRIPTION
When a request gets a 401 and is retried after a token refresh, the retry now carries the original requestInitiatedAt timestamp. This allows the skip-refresh guard in configureUnauthInterceptor to correctly detect that a refresh already occurred and avoid infinite retry loops.

Also adds disableLogging export and minor formatting cleanup.